### PR TITLE
Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ To compile and run all the exercises:
 golings verify
 ```
 
+If you need help with CLI commands:
+
+```sh
+golings --help
+```
+
 A demo running the command `golings run <exercise name>`
 
 ![demo](misc/demo.gif)
@@ -81,11 +87,11 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md)
 
 ## Learning resources
 
-* [Golang official tutorial](https://go.dev/doc/tutorial/)
-* [Go by example](https://gobyexample.com)
-* [Aprenda Go](https://www.youtube.com/playlist?list=PLCKpcjBB_VlBsxJ9IseNxFllf-UFEXOdg)
+- [Golang official tutorial](https://go.dev/doc/tutorial/)
+- [Go by example](https://gobyexample.com)
+- [Aprenda Go](https://www.youtube.com/playlist?list=PLCKpcjBB_VlBsxJ9IseNxFllf-UFEXOdg)
 
 ## Other 'lings
 
-* [rustlings](https://github.com/rust-lang/rustlings)
-* [ziglings](https://github.com/ratfactor/ziglings)
+- [rustlings](https://github.com/rust-lang/rustlings)
+- [ziglings](https://github.com/ratfactor/ziglings)

--- a/README.md
+++ b/README.md
@@ -87,11 +87,11 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md)
 
 ## Learning resources
 
-- [Golang official tutorial](https://go.dev/doc/tutorial/)
-- [Go by example](https://gobyexample.com)
-- [Aprenda Go](https://www.youtube.com/playlist?list=PLCKpcjBB_VlBsxJ9IseNxFllf-UFEXOdg)
+* [Golang official tutorial](https://go.dev/doc/tutorial/)
+* [Go by example](https://gobyexample.com)
+* [Aprenda Go](https://www.youtube.com/playlist?list=PLCKpcjBB_VlBsxJ9IseNxFllf-UFEXOdg)
 
 ## Other 'lings
 
-- [rustlings](https://github.com/rust-lang/rustlings)
-- [ziglings](https://github.com/ratfactor/ziglings)
+* [rustlings](https://github.com/rust-lang/rustlings)
+* [ziglings](https://github.com/ratfactor/ziglings)

--- a/golings/cmd/hint.go
+++ b/golings/cmd/hint.go
@@ -10,7 +10,7 @@ import (
 
 func HintCmd(infoFile string) *cobra.Command {
 	return &cobra.Command{
-		Use:   "hint",
+		Use:   "hint <exercise name>",
 		Short: "Get a hint for an exercise",
 		Args:  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/golings/cmd/run.go
+++ b/golings/cmd/run.go
@@ -13,8 +13,10 @@ import (
 
 func RunCmd(infoFile string) *cobra.Command {
 	return &cobra.Command{
-		Use:           "run [exercise]",
-		Short:         "Run a single exercise",
+		Use:   "run next | <exercise name>",
+		Short: "Run a single exercise",
+		Long: `example next pending exercise : golings run next
+example specific exercise : golings run variables1`,
 		Args:          cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
 		SilenceUsage:  true,
 		SilenceErrors: true,


### PR DESCRIPTION
Hello again, 

Help flag was not in the readme.md  and hint method didn't have the right help text.
Also run help didn't mention   " run next"

I need your input on this one  @mauricioabreu : 

-  do you prefer a cli help text like  ' hint \<exercise name>  ' or  more like ' hint [exercise name] '  ?   Cobra doc says [ ]  should be used for optional input, but hey it's your project :)
- Same for run method. Not sure if the Long arg is really needed.  (run next | \<exercise name>  is not the most explicit message either )
 
Anyway, please tell me what you think of thoses changes.