### PR TITLE
chore: Add a devcontainer file

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+	"name": "golings",
+	"image": "mcr.microsoft.com/devcontainers/base:bullseye",
+	"postCreateCommand": "go install github.com/mauricioabreu/golings/golings@latest",
+	"features": {
+		"ghcr.io/devcontainers/features/go:1": {
+			"version": "latest"
+		},
+		"ghcr.io/stuartleeks/dev-container-features/shell-history:0": {}
+	}
+}

--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ Go to the [releases page](https://github.com/mauricioabreu/golings/releases) and
 
 It's pretty awesome and uses the playground so you can play with the exercises without installing anything.
 
+### DevContainer
+
+1. Install Docker/Podman & VSCode & Configure
+1. Clone the repository and open it in VSCode.
+1. You will be prompted to reopen the code in a devcontainer. The container is pre-configured with go and all of the tools needed to debug go code.
+1. Open a new embeded terminal and run `golings watch` to start the exercises.
+
 ## Doing exercises
 
 All the exercises can be found in the directory `golings/exercises/<topic>`. For every topic there is an additional README file with some resources to get you started on the topic. We really recommend that you have a look at them before you start.


### PR DESCRIPTION
## Why

[DevContainers](https://code.visualstudio.com/docs/devcontainers/containers) are great ways to quickly spin up a new stack / project. Having a devcontainer config might encourage people to use the repo. I know I used the one in rustlings, and when I went looking for a Go equivalent I wanted one.

## How

- Add a devcontainer config file based on debian bullseye
- Include go feature with the latest golang version
- Include shell-history feature which saves the shell history between container launches
- After the container is spun up, install golings cli
- Document basics of how to use the devconainer in README
