### PR TITLE
removed trailing semicolons

### DIFF
--- a/exercises/arrays/arrays1/main.go
+++ b/exercises/arrays/arrays1/main.go
@@ -13,6 +13,6 @@ func main() {
 	colors[1] = "green"
 	colors[2] = "blue"
 
-	fmt.Printf("First color is %s:\n", colors[])
-	fmt.Printf("Last color is %s:\n", colors[])
+	fmt.Printf("First color is %s\n", colors[])
+	fmt.Printf("Last color is %s\n", colors[])
 }


### PR DESCRIPTION
I believe the trailing semicolons at the end of `fmt.Printf` message are not intended.