### PR TITLE
Display progress

### DIFF
--- a/golings/cmd/print.go
+++ b/golings/cmd/print.go
@@ -32,11 +32,11 @@ func PrintList(infoFile string) {
 func RunNextExercise(infoFile string) {
 	ClearScreen()
 
-	progress, done, total, err:= exercises.Progress(infoFile)
+	progress, done, total, err := exercises.Progress(infoFile)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 	} else {
-		color.Blue("Progress: %d/%d (%.2f%%)\n\n", done, total, progress * 100)
+		color.Blue("Progress: %d/%d (%.2f%%)\n\n", done, total, progress*100)
 	}
 
 	exercise, err := exercises.NextPending(infoFile)

--- a/golings/cmd/print.go
+++ b/golings/cmd/print.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"runtime"
@@ -30,6 +31,14 @@ func PrintList(infoFile string) {
 
 func RunNextExercise(infoFile string) {
 	ClearScreen()
+
+	progress, err:= exercises.Progress(infoFile)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+	} else {
+		color.Blue("%.2f%% done.\n\n", progress * 100)
+	}
+
 	exercise, err := exercises.NextPending(infoFile)
 	if err != nil {
 		color.Red("Failed to find next exercises")

--- a/golings/cmd/print.go
+++ b/golings/cmd/print.go
@@ -36,7 +36,7 @@ func RunNextExercise(infoFile string) {
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 	} else {
-		color.Blue("Progress: %d/%d (%.2f%% done)\n\n", done, total, progress * 100)
+		color.Blue("Progress: %d/%d (%.2f%%)\n\n", done, total, progress * 100)
 	}
 
 	exercise, err := exercises.NextPending(infoFile)

--- a/golings/cmd/print.go
+++ b/golings/cmd/print.go
@@ -36,7 +36,7 @@ func RunNextExercise(infoFile string) {
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 	} else {
-        color.Blue("Progress: %d/%d (%.2f%%)\n\n", done, total, progress * 100)
+		color.Blue("Progress: %d/%d (%.2f%% done)\n\n", done, total, progress * 100)
 	}
 
 	exercise, err := exercises.NextPending(infoFile)

--- a/golings/cmd/print.go
+++ b/golings/cmd/print.go
@@ -32,11 +32,11 @@ func PrintList(infoFile string) {
 func RunNextExercise(infoFile string) {
 	ClearScreen()
 
-	progress, err:= exercises.Progress(infoFile)
+	progress, done, total, err:= exercises.Progress(infoFile)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 	} else {
-		color.Blue("%.2f%% done.\n\n", progress * 100)
+        color.Blue("Progress: %d/%d (%.2f%%)\n\n", done, total, progress * 100)
 	}
 
 	exercise, err := exercises.NextPending(infoFile)

--- a/golings/cmd/watch.go
+++ b/golings/cmd/watch.go
@@ -12,6 +12,8 @@ import (
 	"github.com/fatih/color"
 	"github.com/fsnotify/fsnotify"
 	"github.com/spf13/cobra"
+
+	"github.com/mauricioabreu/golings/golings/exercises"
 )
 
 func WatchCmd(infoFile string) *cobra.Command {
@@ -31,6 +33,13 @@ func WatchCmd(infoFile string) *cobra.Command {
 						RunNextExercise(infoFile)
 					}
 				}()
+
+                progress, err:= exercises.Progress(infoFile)
+                if err != nil {
+					fmt.Fprintln(os.Stderr, err)
+                } else {
+                    color.Blue("\n%.2f%% done.", progress * 100)
+                }
 
 				cmdString, err := reader.ReadString('\n')
 				if err != nil {

--- a/golings/cmd/watch.go
+++ b/golings/cmd/watch.go
@@ -12,8 +12,6 @@ import (
 	"github.com/fatih/color"
 	"github.com/fsnotify/fsnotify"
 	"github.com/spf13/cobra"
-
-	"github.com/mauricioabreu/golings/golings/exercises"
 )
 
 func WatchCmd(infoFile string) *cobra.Command {
@@ -33,13 +31,6 @@ func WatchCmd(infoFile string) *cobra.Command {
 						RunNextExercise(infoFile)
 					}
 				}()
-
-                progress, err:= exercises.Progress(infoFile)
-                if err != nil {
-					fmt.Fprintln(os.Stderr, err)
-                } else {
-                    color.Blue("\n%.2f%% done.", progress * 100)
-                }
 
 				cmdString, err := reader.ReadString('\n')
 				if err != nil {

--- a/golings/exercises/exercises_suite_test.go
+++ b/golings/exercises/exercises_suite_test.go
@@ -95,9 +95,11 @@ var _ = Describe("Exercises", func() {
 	Describe("Reporting progress", func() {
 		When("half exercises pending", func() {
 			It("reports 50%% progress", func() {
-				progress, err := exercises.Progress("../fixtures/progress/info.toml")
+				progress, done, total, err := exercises.Progress("../fixtures/progress/info.toml")
 
 				Expect(err).NotTo(HaveOccurred())
+				Expect(done).To(Equal(1))
+				Expect(total).To(Equal(2))
 				Expect(progress).To(Equal(float32(0.5)))
 			})
 		})

--- a/golings/exercises/exercises_suite_test.go
+++ b/golings/exercises/exercises_suite_test.go
@@ -92,4 +92,14 @@ var _ = Describe("Exercises", func() {
 			})
 		})
 	})
+	Describe("Reporting progress", func() {
+		When("half exercises pending", func() {
+			It("reports 50%% progress", func() {
+				progress, err := exercises.Progress("../fixtures/progress/info.toml")
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(progress).To(Equal(float32(0.5)))
+			})
+		})
+	})
 })

--- a/golings/exercises/list.go
+++ b/golings/exercises/list.go
@@ -58,3 +58,18 @@ func Find(exercise string, infoFile string) (Exercise, error) {
 
 	return Exercise{}, ErrExerciseNotFound
 }
+
+func Progress(infoFile string) (float32, error) {
+    allExercises, err := List(infoFile)
+    if err != nil {
+        return 0.0, err
+    }
+    done := []Exercise{}
+    for _, exercise := range allExercises {
+        if exercise.State() == Done {
+            done = append(done, exercise)
+        }
+    }
+
+    return float32(len(done)) / float32(len(allExercises)), nil
+}

--- a/golings/exercises/list.go
+++ b/golings/exercises/list.go
@@ -60,16 +60,16 @@ func Find(exercise string, infoFile string) (Exercise, error) {
 }
 
 func Progress(infoFile string) (float32, error) {
-    allExercises, err := List(infoFile)
-    if err != nil {
-        return 0.0, err
-    }
-    done := []Exercise{}
-    for _, exercise := range allExercises {
-        if exercise.State() == Done {
-            done = append(done, exercise)
-        }
-    }
+	allExercises, err := List(infoFile)
+	if err != nil {
+		return 0.0, err
+	}
+	done := []Exercise{}
+	for _, exercise := range allExercises {
+		if exercise.State() == Done {
+			done = append(done, exercise)
+		}
+	}
 
-    return float32(len(done)) / float32(len(allExercises)), nil
+	return float32(len(done)) / float32(len(allExercises)), nil
 }

--- a/golings/exercises/list.go
+++ b/golings/exercises/list.go
@@ -59,10 +59,10 @@ func Find(exercise string, infoFile string) (Exercise, error) {
 	return Exercise{}, ErrExerciseNotFound
 }
 
-func Progress(infoFile string) (float32, error) {
+func Progress(infoFile string) (float32, int, int, error) {
 	allExercises, err := List(infoFile)
 	if err != nil {
-		return 0.0, err
+		return 0.0, 0, 0, err
 	}
 	done := []Exercise{}
 	for _, exercise := range allExercises {
@@ -71,5 +71,8 @@ func Progress(infoFile string) (float32, error) {
 		}
 	}
 
-	return float32(len(done)) / float32(len(allExercises)), nil
+    totalDone := len(done)
+    total := len(allExercises)
+
+	return float32(totalDone) / float32(total), totalDone, total, nil
 }

--- a/golings/exercises/list.go
+++ b/golings/exercises/list.go
@@ -71,8 +71,8 @@ func Progress(infoFile string) (float32, int, int, error) {
 		}
 	}
 
-    totalDone := len(done)
-    total := len(allExercises)
+	totalDone := len(done)
+	total := len(allExercises)
 
 	return float32(totalDone) / float32(total), totalDone, total, nil
 }

--- a/golings/fixtures/progress/info.toml
+++ b/golings/fixtures/progress/info.toml
@@ -1,0 +1,11 @@
+[[exercises]]
+name = "pending1"
+path = "../fixtures/pending1/main.go"
+mode = "compile"
+hint = ""
+
+[[exercises]]
+name = "success1"
+path = "../fixtures/success1/main.go"
+mode = "compile"
+hint = ""


### PR DESCRIPTION
This adds a simple progress indicator in the UI. Not as fancy as the one on rustlings yet, but it does the job :)

Example:

```
Progress: 12/43 (27.91%)

Failed to compile the exercise exercises/switch/switch1/main.go

Check the output below:

# command-line-arguments
exercises/switch/switch1/main.go:10:2: status declared and not used
exercises/switch/switch1/main.go:12:7: cannot convert "open" (untyped string constant) to type bool
exercises/switch/switch1/main.go:14:7: cannot convert "closed" (untyped string constant) to type bool

If you feel stuck, ask a hint by executing `golings hint switch1`

``` 