### PR TITLE
fix: interactive mode for vim/neovim

### DIFF
--- a/golings/cmd/watch.go
+++ b/golings/cmd/watch.go
@@ -86,7 +86,7 @@ func WatchEvents(updateF chan<- string) {
 	}
 
 	for event := range watcher.Events {
-		if event.Has(fsnotify.Write) {
+		if event.Has(fsnotify.Write) || event.Has(fsnotify.Rename) {
 			updateF <- event.Name
 		}
 	}


### PR DESCRIPTION
Adds a condition for the rename event to handle "write" events in vim/neovim which does not fire a typical write event due to the way it handles buffers writing to temporary files.

`golings watch` was not working when editing the files in neovim, this solves that.

I noticed a similar closed PR that did similar using the 'Remove' event, this one is tested and works specifically for how neovim writes files.