### PR TITLE
Fix: stopped golings watch erroring upon completing all exercises

### DIFF
--- a/golings/cmd/print.go
+++ b/golings/cmd/print.go
@@ -39,6 +39,15 @@ func RunNextExercise(infoFile string) {
 		color.Blue("Progress: %d/%d (%.2f%%)\n\n", done, total, progress*100)
 	}
 
+	if progress == 1.0 {
+		color.Green("Congratulations!!\n\n")
+		color.Green("You have completed all %d of the currently available exercises.")
+		color.Blue("If you enjoyed working through this introduction to Golang please give the github repository a star")
+		color.White("\t> https://github.com/mauricioabreu/golings <")
+
+		return;
+	}
+
 	exercise, err := exercises.NextPending(infoFile)
 	if err != nil {
 		color.Red("Failed to find next exercises")

--- a/golings/cmd/print.go
+++ b/golings/cmd/print.go
@@ -39,11 +39,14 @@ func RunNextExercise(infoFile string) {
 		color.Blue("Progress: %d/%d (%.2f%%)\n\n", done, total, progress*100)
 	}
 
-	if progress == 1.0 {
-		color.Green("Congratulations!!\n\n")
-		color.Green("You have completed all %d of the currently available exercises.")
-		color.Blue("If you enjoyed working through this introduction to Golang please give the github repository a star")
-		color.White("\t> https://github.com/mauricioabreu/golings <")
+	if done == total {
+		color.Green("Congratulations!!\n")
+		color.Green("You have completed all %d of the currently available exercises.", total)
+		color.Blue("If you enjoyed working through this introduction to Golang,")
+		color.Blue("please give the github repository a star")
+		color.White("> https://github.com/mauricioabreu/golings <\n\n\n")
+
+		color.Yellow("To quit out of watch, please type `exit` and hit enter:")
 
 		return;
 	}


### PR DESCRIPTION
## Description & motivation
This problem caused me confusion after I had just finished the exercise pack, so I inserted a check in the `RunNextExercise()` function called by `golings watch` for printing out information to the console.

This check compares the variables done and total returned by `exercises.Progress()` called at the beginning of the function, if equal it prints out congratulations and returns before executing the search for the next pending exercise

## Screenshots:
![golings verify to prove exercise completion](https://github.com/user-attachments/assets/113a6058-0267-4990-93a3-fad7c5b7d84c)

![new golings watch showing the printout](https://github.com/user-attachments/assets/c3f8db82-3bf9-4b56-a7be-bac84454ea3b)


![Output of test suite](https://github.com/user-attachments/assets/b51e2877-3723-4dff-aa1e-53b1780c202c)

## Validation:

As shown above my changes do not interfere with the tested functions from the cmd_suite_test.go


## Checklist:
<!---
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.
Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.
-->
- [x] My pull request represents one logical piece of work.
- [x] My commits are related to the pull request and look clean.
- [x] I have run appropriate tests.