### PR TITLE
Renamed function call_me to callMe

### DIFF
--- a/exercises/functions/functions1/main.go
+++ b/exercises/functions/functions1/main.go
@@ -5,5 +5,5 @@
 package main
 
 func main() {
-	call_me()
+	callMe()
 }

--- a/exercises/functions/functions3/main.go
+++ b/exercises/functions/functions3/main.go
@@ -7,10 +7,10 @@ package main
 import "fmt"
 
 func main() {
-	call_me()
+	callMe()
 }
 
-func call_me(num int) {
+func callMe(num int) {
 	for n := 0; n <= num; n++ {
 		fmt.Printf("Num is %d\n", n)
 	}

--- a/info.toml
+++ b/info.toml
@@ -46,7 +46,7 @@ path = "exercises/functions/functions1/main.go"
 mode = "compile"
 hint = """
 The main function is calling another function that it expects to exist.
-It expects a function named `call_me` to exist and receive no arguments."""
+It expects a function named `callMe` to exist and receive no arguments."""
 
 [[exercises]]
 name = "functions2"


### PR DESCRIPTION
According to:
ST1003 [default]: should not use underscores in Go names; func call_me should be callMe